### PR TITLE
feat(OpenChemLibEditor): Add Atom Selection Listener with Reaction Support

### DIFF
--- a/src/main/java/ch/artaios/openchemlib/vaadin/AtomSelectionEvent.java
+++ b/src/main/java/ch/artaios/openchemlib/vaadin/AtomSelectionEvent.java
@@ -1,0 +1,35 @@
+package ch.artaios.openchemlib.vaadin;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+
+import java.util.List;
+
+@DomEvent("ocl-selectionchange")
+public class AtomSelectionEvent extends ComponentEvent<OpenChemLibEditor<?>> {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final String selectedAtomsJson;
+
+    public AtomSelectionEvent(
+            OpenChemLibEditor<?> source,
+            boolean fromClient,
+            @EventData("JSON.stringify(event.detail.selectedAtoms)") String selectedAtomsJson) {
+        super(source, fromClient);
+        this.selectedAtomsJson = selectedAtomsJson;
+    }
+
+    public String getSelectedAtomsJson() {
+        return selectedAtomsJson;
+    }
+
+    public List<Integer> getSelectedAtoms() {
+        try {
+            return objectMapper.readValue(selectedAtomsJson, new TypeReference<List<Integer>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse selected atoms JSON: " + selectedAtomsJson, e);
+        }
+    }
+}

--- a/src/main/java/ch/artaios/openchemlib/vaadin/AtomSelectionEvent.java
+++ b/src/main/java/ch/artaios/openchemlib/vaadin/AtomSelectionEvent.java
@@ -7,27 +7,53 @@ import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
 
 import java.util.List;
+import java.util.Map;
 
 @DomEvent("ocl-selectionchange")
 public class AtomSelectionEvent extends ComponentEvent<OpenChemLibEditor<?>> {
     private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final String mode;
     private final String selectedAtomsJson;
 
     public AtomSelectionEvent(
             OpenChemLibEditor<?> source,
             boolean fromClient,
-            @EventData("JSON.stringify(event.detail.selectedAtoms)") String selectedAtomsJson) {
+            @EventData("event.detail.mode") String mode,
+            @EventData("event.detail.selectedAtoms") String selectedAtomsJson) {
         super(source, fromClient);
+        this.mode = mode;
         this.selectedAtomsJson = selectedAtomsJson;
+    }
+
+    public String getMode() {
+        return mode;
     }
 
     public String getSelectedAtomsJson() {
         return selectedAtomsJson;
     }
 
-    public List<Integer> getSelectedAtoms() {
+    public Map<String, List<List<Integer>>> getSelectedReactionAtoms() {
         try {
-            return objectMapper.readValue(selectedAtomsJson, new TypeReference<List<Integer>>() {});
+            if (mode.equals(OpenChemLibEditor.Mode.REACTION.toString().toLowerCase())) {
+                return objectMapper.readValue(selectedAtomsJson, new TypeReference<Map<String, List<List<Integer>>>>() {});
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse selected atoms JSON: " + selectedAtomsJson, e);
+        }
+    }
+
+    public List<Integer> getSelectedMoleculeAtoms() {
+        try {
+            if (mode.equals(OpenChemLibEditor.Mode.MOLECULE.toString().toLowerCase())) {
+                return objectMapper.readValue(selectedAtomsJson, new TypeReference<List<Integer>>() {
+                });
+            } else {
+                return null;
+            }
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse selected atoms JSON: " + selectedAtomsJson, e);
         }

--- a/src/main/java/ch/artaios/openchemlib/vaadin/OpenChemLibEditor.java
+++ b/src/main/java/ch/artaios/openchemlib/vaadin/OpenChemLibEditor.java
@@ -175,4 +175,8 @@ public abstract class OpenChemLibEditor<T> extends AbstractSinglePropertyField<O
     public ContextMenu getContextMenu() {
         return contextMenu;
     }
+
+    public Registration addAtomSelectionListener(ComponentEventListener<AtomSelectionEvent> listener) {
+        return addListener(AtomSelectionEvent.class, listener);
+    }
 }

--- a/src/main/resources/META-INF/resources/frontend/openchemlib-editor-init.js
+++ b/src/main/resources/META-INF/resources/frontend/openchemlib-editor-init.js
@@ -33,22 +33,62 @@ try {
 
         this.addEventListener('change', function(e) {
             if (e.detail.type === 'selection') {
-                var selAtoms = [];
-                var mol = this.getMolecule();
-                if (!mol) {
-                    return;
-                }
-                for (var i = 0, n = mol.getAllAtoms(); i < n; i++) {
-                    if (mol.isSelectedAtom(i)) {
-                        selAtoms.push(i);
+                var selAtoms;
+                if (this.mode === CanvasEditorElement.MODE.MOLECULE) {
+                    // Handle single molecules
+                    var mol = this.getMolecule();
+                    if (!mol) {
+                        return;
+                    }
+                    selAtoms = [];
+                    for (var i = 0, n = mol.getAllAtoms(); i < n; i++) {
+                        if (mol.isSelectedAtom(i)) {
+                            selAtoms.push(i);
+                        }
+                    }
+                } else if (this.mode === CanvasEditorElement.MODE.REACTION) {
+                    // Handle reactions
+                    var reaction = this.getReaction();
+                    if (!reaction) {
+                        return;
+                    }
+                    selAtoms = { reactants: [], products: [] };
+                    var reactants = reaction.getReactants();
+                    var products = reaction.getProducts();
+                    if (reactants) {
+                        for (var r = 0; r < reactants; r++) {
+                            var mol = reaction.getReactant(r);
+                            var sel = [];
+                            for (var i = 0, n = mol.getAllAtoms(); i < n; i++) {
+                                if (mol.isSelectedAtom(i)) {
+                                    sel.push(i);
+                                }
+                            }
+                            selAtoms.reactants.push(sel);
+                        }
+                    }
+                    if (products) {
+                        for (var p = 0; p < products; p++) {
+                            var mol = reaction.getProduct(p);
+                            var sel = [];
+                            for (var i = 0, n = mol.getAllAtoms(); i < n; i++) {
+                                if (mol.isSelectedAtom(i)) {
+                                    sel.push(i);
+                                }
+                            }
+                            selAtoms.products.push(sel);
+                        }
                     }
                 }
                 this.dispatchEvent(new CustomEvent('ocl-selectionchange', {
                     detail: {
                         type: e.detail.type,
                         isUserEvent: e.detail.isUserEvent,
-                        selectedAtoms: selAtoms
-                    }
+                        mode: this.mode,
+                        selectedAtoms: JSON.stringify(selAtoms)
+                    },
+                    bubbles: true,
+                    composed: true
                 }));
             }
         });

--- a/src/main/resources/META-INF/resources/frontend/openchemlib-editor-init.js
+++ b/src/main/resources/META-INF/resources/frontend/openchemlib-editor-init.js
@@ -30,6 +30,28 @@ try {
                     this.idcode = anyRxnStringToIdCode(data);
             }
         }
+
+        this.addEventListener('change', function(e) {
+            if (e.detail.type === 'selection') {
+                var selAtoms = [];
+                var mol = this.getMolecule();
+                if (!mol) {
+                    return;
+                }
+                for (var i = 0, n = mol.getAllAtoms(); i < n; i++) {
+                    if (mol.isSelectedAtom(i)) {
+                        selAtoms.push(i);
+                    }
+                }
+                this.dispatchEvent(new CustomEvent('ocl-selectionchange', {
+                    detail: {
+                        type: e.detail.type,
+                        isUserEvent: e.detail.isUserEvent,
+                        selectedAtoms: selAtoms
+                    }
+                }));
+            }
+        });
     }
 
     CanvasEditorElement.prototype.copy=function() {

--- a/src/test/java/ch/artaios/openchemlib/vaadin/EditorTestView.java
+++ b/src/test/java/ch/artaios/openchemlib/vaadin/EditorTestView.java
@@ -26,6 +26,11 @@ public class EditorTestView extends VerticalLayout {
         AtomicBoolean withinEvent = new AtomicBoolean(false);
         final StructureEditor structureEditor = new StructureEditor(false);
 
+        structureEditor.addAtomSelectionListener(event -> {
+            String message = "Atoms selected:\n" + event.getSelectedAtoms();
+            System.out.println(message);
+        });
+
         final TextField idcode = new TextField("IdCode");
         idcode.setWidthFull();
         idcode.setReadOnly(true);

--- a/src/test/java/ch/artaios/openchemlib/vaadin/EditorTestView.java
+++ b/src/test/java/ch/artaios/openchemlib/vaadin/EditorTestView.java
@@ -27,7 +27,7 @@ public class EditorTestView extends VerticalLayout {
         final StructureEditor structureEditor = new StructureEditor(false);
 
         structureEditor.addAtomSelectionListener(event -> {
-            String message = "Atoms selected:\n" + event.getSelectedAtoms();
+            String message = "Atoms selected in molecule:\n" + event.getSelectedMoleculeAtoms();
             System.out.println(message);
         });
 
@@ -82,6 +82,12 @@ public class EditorTestView extends VerticalLayout {
         // ---
 
         final ReactionEditor reactionEditor = new ReactionEditor(false);
+
+        reactionEditor.addAtomSelectionListener(event -> {
+            String message = "Atoms selected in reaction:\n" + event.getSelectedReactionAtoms();
+            System.out.println(message);
+        });
+
         reactionEditor.setValue(ChemUtils.getReaction("gJX@@eKU@@ gGQHDHaImfh@!defH@DAIfUVjj`@"));
         reactionEditor.addValueChangeListener(event -> System.out.println("ReactionEditor change event: " + reactionEditor.getValue()));
         reactionEditor.setWidth(45, Unit.VW);


### PR DESCRIPTION
### Overview
This PR introduces an **AtomSelectionEvent** for the `OpenChemLibEditor`, allowing developers to listen for changes in the atom selection state. This enhancement supports both **molecule mode** and **reaction mode**, providing a consistent way to retrieve selected atoms.

### Key Features
1. **Atom Selection Event for Single Molecules**
    - When the editor is in **MOLECULE mode**, the event returns an `ArrayList<Integer>` of selected atom indices.
    - Developers can register an **atom selection listener** to respond to selection changes.

2. **Extended Support for Reactions**
    - When the editor is in **REACTION mode**, the event provides a structured map of selected atoms:
        - `reactants` → List of lists, where the outer list corresponds to reactant molecules, and the inner list contains selected atom indices.
        - `products` → Similar structure as `reactants`, but for product molecules.

### Usage Example
#### Registering an Atom Selection Listener
```java
editor.addAtomSelectionListener(event -> {
    if (event.getMode().equals(OpenChemLibEditor.Mode.MOLECULE.name().toLowerCase())) {
        List<Integer> selectedAtoms = event.getSelectedMoleculeAtoms();
        System.out.println("Selected molecule atoms: " + selectedAtoms);
    } else if (event.getMode().equals(OpenChemLibEditor.Mode.REACTION.name().toLowerCase())) {
        Map<String, List<List<Integer>>> selection = event.getSelectedReactionAtoms();
        System.out.println("Selected reactant atoms: " + selection.get("reactants"));
        System.out.println("Selected product atoms: " + selection.get("products"));
    }
});
```

### Implementation Details
- The selection state is retrieved from the OpenChemLib-JS API when the `"selection"` change event fires.
- The selected atoms are extracted from the molecule or reaction object and exposed in the `AtomSelectionEvent`.
- A **new custom event** (`ocl-selectionchange`) is dispatched to ensure that the selection details are properly passed to the Vaadin component.

### Why This Is Useful
- Enables **interactive** applications where atom selection matters (e.g., property analysis, structural modifications, or filtering).
- **Supports both molecules and reactions** in a standardized way.
- Follows Vaadin’s event-based approach, making it easy to integrate.